### PR TITLE
More generic way to split fields in input zonefiles

### DIFF
--- a/largeZoneParser.py
+++ b/largeZoneParser.py
@@ -13,7 +13,7 @@ def get_ns_set(zonefile=None, extension=None):
 
     with open(zonefile) as f:
         for line in f.readlines():
-            sp = line.lower().split('\t')
+            sp = line.lower().split()
             ns_entry = ''
 
             if len(sp) > 3:


### PR DESCRIPTION
Hey Giovane,

Just a small change to better handle zonefiles as some of then are split on \t and others without (at least in our environment). split() splits on whitespace in general

Dirk