### PR TITLE
fixed some things to get this going in our environment

### DIFF
--- a/fullDepParser.py
+++ b/fullDepParser.py
@@ -27,7 +27,7 @@ if __name__ == '__main__':
     # Read the command line arguments
     argparser = argparse.ArgumentParser(
         description="Reviews the dependency detection and filter outs only full cyclic dependencies")
-    argparser.add_argument('cycle-file', type=str, help="File with the output from findCyclicDep")
+    argparser.add_argument('cycle_file', type=str, help="File with the output from findCyclicDep")
     argparser.add_argument('output_file', type=str, help="File to save the full cycle cases")
     args = argparser.parse_args()
 

--- a/largeZoneParser.py
+++ b/largeZoneParser.py
@@ -13,7 +13,7 @@ def get_ns_set(zonefile=None, extension=None):
 
     with open(zonefile) as f:
         for line in f.readlines():
-            sp = line.lower().split('\t')
+            sp = line.lower().split()
             ns_entry = ''
 
             if len(sp) > 3:
@@ -36,10 +36,11 @@ def zone_parser(zonefile=None, zonename=None, output_file=None):
 
     if len(nsset) >0:
         with open(output_file, 'w') as aus:
+            logging.info('Info reading zonefile for domain: {}'.format(zonefile))
             for k in nsset:
                 aus.write(f"{k}\n")
     else:
-        logging.info('Error with largeZoneParser.py: could not extract NS records from zone file')
+        logging.info('Error with largeZoneParser.py: could not extract NS records from zone file'.format(zonefile))
         logging.info('Please run CycleHunter step-by-step and changeZoneParser.py to your zone synthax')
         sys.exit(output_file + "  has no NS records; stop here. Plase check if largeZoneParser correctly parsers your zone file")
 if __name__ == '__main__':


### PR DESCRIPTION
zoneMatcher.py
- regex for definining NS records is better
- conditional under 'if not foundZone:'  is wrong
- 
fulldepparser.py: split() is better because split('\n') is too restrictive