### PR TITLE
refactored Dockerfile to account for asyncio's dependencies and replaced Pypy 3.7 with Python 3.9.2 as base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
-FROM pypy:3.7-slim
+FROM python:3.9.2-slim-buster
 
-RUN pip install dnspython tqdm
+ENV APP_DIR /cyclehunter
 
-COPY *.py /cyclehunter/
+WORKDIR ${APP_DIR}
 
-WORKDIR /cyclehunter
+COPY *.py requirements.txt ${APP_DIR}/
+
+RUN pip install -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -64,13 +64,13 @@ docker build -t sidn/cyclehunter --no-cache .
 
 ```shell
 
-docker run -it -v $(pwd):/data --rm sidn/cyclehunter pypy3 CycleHunter.py --zonefile /data/org.txt --origin ".org" --save-file /data/org-final.out --base-dir /data --workers 6
+docker run -it -v $(pwd):/data --rm sidn/cyclehunter python3 CycleHunter.py --zonefile /data/org.txt --origin ".org" --save-file /data/org-final.out --base-dir /data --workers 6
 
 or to run specific step within the container as per the general instructions:
 
 e.g.
 
-docker run -it -v $(pwd):/data --rm sidn/cyclehunter pypy3 findCyclicDep.py /data/$output2 /data/$output3
+docker run -it -v $(pwd):/data --rm sidn/cyclehunter python3 findCyclicDep.py /data/$output2 /data/$output3
 
 ```
 


### PR DESCRIPTION
* refactored Dockerfile to account for asyncio's dependencies
* using requirements.txt as for pip in container build
* switched from pypy 3.7 to python 3.9.2 as base
* amended README.md

@seb-at-nzrs: the new asyncio dependencies as async_lru were breaking the container run, the above refactoring addresses this and also replaces Pypy with CPython 3.9.2 as discussed.