### PR TITLE
Don't display progress bar when not attached to tty.

### DIFF
--- a/CyclicDetector.py
+++ b/CyclicDetector.py
@@ -286,7 +286,7 @@ async def probeNSes(setOfNSes, workers=5):
     sem = asyncio.Semaphore(value=workers)
 
     aws = [probe_ns_limited_concurrency(nsname, sem) for nsname in setOfNSes]
-    for coro in tqdm.asyncio.tqdm.as_completed(aws):
+    for coro in tqdm.tqdm(asyncio.as_completed(aws),disable=None,total=len(aws)):
         nsname, res = await coro
         results[nsname] = res
 


### PR DESCRIPTION
When I ran the process in batch directing stdout and err to a file, it was filled with control characters by the progress bar (about 700K). This small change detects when the output is not a tty, and does not display a progress bar.