### PR TITLE
fix typo zone.lowe() -> zone.lower()

### DIFF
--- a/findCyclicDep.py
+++ b/findCyclicDep.py
@@ -1021,7 +1021,7 @@ def sortDepsNew(timeOutWOBailick):
                     clearedForNX.append(zone.lower())
 
                 elif "OK" in k:
-                    clearedZonesForOK.append(zone.lowe())
+                    clearedZonesForOK.append(zone.lower())
 
                 elif "BROKEN" in k:
                     domainsBrokeNS.append(zone.lower())


### PR DESCRIPTION
this fixes
```
Traceback (most recent call last):
  File "CycleHunter.py", line 54, in <module>
    find_cycles(output2, output3)
  File "/cyclehunter/findCyclicDep.py", line 1154, in find_cycles
    cyclic = sortDepsNew(zonesWoBailiwick)
  File "/cyclehunter/findCyclicDep.py", line 1024, in sortDepsNew
    clearedZonesForOK.append(zone.lowe())
AttributeError: 'str' object has no attribute 'lowe'
``` 
